### PR TITLE
Remove "no data message" from tooltip

### DIFF
--- a/ArenaMasterPvPInspect/core.lua
+++ b/ArenaMasterPvPInspect/core.lua
@@ -163,8 +163,6 @@ function AMPVP_AddTooltipDetails(userName, addSpacePlus, frameOwner, ownerAnchor
 
 	else
 		if GameTooltip.ampvpHooked == nil then
-			GameTooltip:AddLine(" ")
-			GameTooltip:AddLine("ArenaMaster - No data available")
 			if addSpacePlus then
 				GameTooltip:AddLine(" ")
 			end


### PR DESCRIPTION
We  don't need to unnecessarily pollute the tooltip if arenamaster has no data

![image](https://user-images.githubusercontent.com/4814573/111467664-9abf6280-871c-11eb-9866-38d220c480d2.png)
![image](https://user-images.githubusercontent.com/4814573/111467679-9e52e980-871c-11eb-8044-07813469a36b.png)
