### PR TITLE
fix: stop guild/community roster tooltip from duplicating data endlessly

### DIFF
--- a/ArenaMasterPvPInspect/ui/ui.lua
+++ b/ArenaMasterPvPInspect/ui/ui.lua
@@ -352,6 +352,9 @@ hooksecurefunc(GameTooltip, "Hide", function(self)
 		GameTooltip.ampvpHooked = nil
 	end
 
+	-- Clear the per-member guard so the next hover re-populates the tooltip.
+	GameTooltip.ampvpLastName = nil
+
 	if friendsTooltipShown then
 		friendsTooltipShown = false
 	end
@@ -385,8 +388,12 @@ GameTooltip:HookScript("OnUpdate", function(self)
 
 		local finalName = aname.."-"..arealm;
 
-		if finalName ~= nil and finalName ~= "" then
+		-- OnUpdate fires every frame; only add our details once per member,
+		-- otherwise AMPVP_AddTooltipDetails appends the same block again each
+		-- frame and the tooltip grows into an endless duplicate list.
+		if finalName ~= nil and finalName ~= "" and GameTooltip.ampvpLastName ~= finalName then
 			AMPVP_AddTooltipDetails(finalName, false)
+			GameTooltip.ampvpLastName = finalName
 		end
 
 	end


### PR DESCRIPTION
## Summary

Fixes #23 — the guild/community roster tooltip was building a long, endlessly-duplicated list of data.

## Root cause

`GameTooltip`'s `OnUpdate` hook fires every frame. The LFG branch already guards re-adds with `GameTooltip.ampvpLastID`, but the community/guild roster branch (`entry.memberInfo`) had **no guard**, so it called `AMPVP_AddTooltipDetails` on *every frame*. That function appends its data block (or the "No data available" message) and calls `Show()` without clearing, so the same information was re-appended each frame and the tooltip grew into an endless duplicate list.

## Fix

Mirror the existing `ampvpLastID` idiom: track the last member name in `GameTooltip.ampvpLastName` and only add details once per member, then clear the guard on tooltip `Hide` so re-hovering re-populates.

`ArenaMasterPvPInspect/ui/ui.lua` (+8 / −1)

## Verification

- `luac -p ArenaMasterPvPInspect/ui/ui.lua` passes (syntax clean).
- Logic reviewed against the existing per-frame guard idiom; guard clears on `Hide` so moving between members re-populates correctly.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)