### PR TITLE
fix: stop friends-list mouseover errors on offline BNet friends (#19)

### DIFF
--- a/ArenaMasterPvPInspect/ui/ui.lua
+++ b/ArenaMasterPvPInspect/ui/ui.lua
@@ -471,9 +471,19 @@ local function friedsListFunc2(self)
 		end
 	end
 
-	local accData = C_BattleNet.GetFriendGameAccountInfo(bnetIndex, 1)
+	-- No BNet friend index on this tooltip button (e.g. a regular WoW friend
+	-- or an empty entry), so there is nothing for us to inspect.
+	if type(bnetIndex) ~= "number" then return end
 
-	if accData == nil then return end
+	-- Read the game account straight off the account info. Offline BNet
+	-- friends have no active game account, so we stop here for them. This also
+	-- avoids calling C_BattleNet.GetFriendGameAccountInfo, which some addons
+	-- (e.g. ElvUI/MerathilisUI) wrap in a way that errors when the friend is
+	-- offline. See issue #19.
+	local accountInfo = C_BattleNet.GetFriendAccountInfo(bnetIndex)
+	local accData = accountInfo and accountInfo.gameAccountInfo
+
+	if accData == nil or not accData.isOnline then return end
 
 	local realm, name = accData.realmName, accData.characterName
 


### PR DESCRIPTION
## Summary
Mousing over an **offline Battle.net friend** in the friends list spammed ~168 Lua errors. `friedsListFunc2` (hooked to `FriendsTooltip:Show`) called `C_BattleNet.GetFriendGameAccountInfo` for every friend, including offline ones with no active game account. Addons that wrap that function (e.g. ElvUI/MerathilisUI) error when indexing the nil `gameAccountInfo` for an offline friend, so the call ArenaMaster makes triggered the cascade.

## Fix
- Read the game account directly from `C_BattleNet.GetFriendAccountInfo` and bail out when the friend is offline or has no game account — avoiding the wrapped `GetFriendGameAccountInfo` call entirely.
- Guard against a missing/non-numeric BNet index on the tooltip button.

Online friends keep the same tooltip behaviour.

## Verification
- Mocked 4-case logic test (online / offline / no-account / non-numeric index).
- `luac` syntax check passes on `ArenaMasterPvPInspect/ui/ui.lua`.

Fixes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)